### PR TITLE
FT-0008 - Convert Private Key Format from HEX to Bech32 (NSEC)

### DIFF
--- a/src/app/[lng]/settings/recovery/page.tsx
+++ b/src/app/[lng]/settings/recovery/page.tsx
@@ -14,6 +14,8 @@ import { appTheme } from '@/config/exports';
 import { getUserStoragedKey } from '@/utils';
 import { CACHE_BACKUP_KEY } from '@/utils/constants';
 import { useConfig, useIdentity } from '@lawallet/react';
+import { nip19 } from 'nostr-tools';
+import { hexToBytes } from '@noble/hashes/utils';
 
 export default function Page() {
   const t = useTranslations();
@@ -36,7 +38,8 @@ export default function Page() {
     const storagedKey = await getUserStoragedKey(config.storage);
     if (!storagedKey) return;
 
-    setUserStoragedKey(storagedKey);
+    const nsec = nip19.nsecEncode(hexToBytes(storagedKey));
+    setUserStoragedKey(nsec);
   };
 
   useEffect(() => {


### PR DESCRIPTION
Use of a private key in Bech32 format.

The login already allowed access with Nsec, so only the way the key was displayed to the user was changed.